### PR TITLE
fix: try renaming relation so it doesn't get overwritten

### DIFF
--- a/macros/bigquery/materialized_view.sql
+++ b/macros/bigquery/materialized_view.sql
@@ -1,4 +1,4 @@
-{% materialization materialized_view, adapter='bigquery' -%}
+{% materialization cta_materialized_view, adapter='bigquery' -%}
 
   {% set full_refresh_mode = (should_full_refresh()) %}
 

--- a/macros/default/materialized_view.sql
+++ b/macros/default/materialized_view.sql
@@ -1,4 +1,4 @@
-{% materialization materialized_view, default -%}
+{% materialization cta_materialized_view, default -%}
 
   {% set full_refresh_mode = (should_full_refresh()) %}
 

--- a/macros/snowflake/materialized_view.sql
+++ b/macros/snowflake/materialized_view.sql
@@ -1,4 +1,4 @@
-{% materialization materialized_view, adapter='snowflake' -%}
+{% materialization cta_materialized_view, adapter='snowflake' -%}
 
   {% set original_query_tag = set_query_tag() %}
 


### PR DESCRIPTION
[dbt-core 1.6](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid) added the `materialized view` materialization type. This means that when using dbt 1.6 and higher, the official dbt packages are used for `materialized view` materialization. The problem with the official package is that it doesn't have the ability to add view authorization and gets a bit scuffed in our dev enviroment (idk whats different in there than in prod but the official `materialized view` doesnt even run 🙃 )

This PR changes the name of the materialization to `cta_materialized_view` so that we can use this package to continue creating, updating, and authorizing matview with dbt how we normally do.

Note on this, in order to apply these changes:

- [ ] We have to run `dbt-deps` and copy the new generated package for `dbt-materialized-views` into GCS.
- [ ] Once thats done, we have to update the `dbt_project.yml` file so that we use the `cta_materialized_view` materialization instead of `materialized_view` in our [2_partner_matviews](https://github.com/community-tech-alliance/dbt-cta/blob/main/dbt-cta/dbt_project.yml#L49) config


I've deployed this to our dev environment and have run some tests on the [actblue dag ](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid)

- [Normal Run (refresh matview)](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid?dag_run_id=scheduled__2024-08-04T21%3A45%3A00%2B00%3A00&task_id=actblue_0_partner_a.dbt_tasks.dbt_actblue.dbt_run_partner&tab=logs)
- [Full-Refresh Run (Create matview and authorize)](https://f9ebbc83f6f3414381d6fa9a52957253-dot-us-central1.composer.googleusercontent.com/dags/actblue/grid?dag_run_id=manual__2024-08-05T21%3A09%3A06%2B00%3A00&task_id=actblue_0_partner_a.dbt_tasks.dbt_actblue.dbt_run_partner)